### PR TITLE
 Add poweron architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: go
+arch:
+   - ppc64le
+   - amd64
 
 go:
     - master
@@ -12,5 +15,11 @@ go:
     - 1.6.x
     - 1.5.x
     - 1.4.x
+
+jobs:
+  exclude :
+    - arch : ppc64le
+      go : 
+       - 1.4.x
 
 script: go test -v -bench . -benchmem ./...


### PR DESCRIPTION
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,For more info tag @gerrith3.
